### PR TITLE
Expose eval with cli, add evaluation of expression only

### DIFF
--- a/simplechrome/errors.py
+++ b/simplechrome/errors.py
@@ -12,6 +12,7 @@ __all__ = [
     "LauncherError",
     "InputError",
     "NavigationError",
+    "EvaluationError"
 ]
 
 
@@ -53,3 +54,7 @@ class InputError(Exception):
 
 class NavigationError(Exception):
     """For navigation errors"""
+
+
+class EvaluationError(Exception):
+    """For evaluation errors"""

--- a/simplechrome/frame_manager.py
+++ b/simplechrome/frame_manager.py
@@ -470,25 +470,44 @@ class Frame(EventEmitter):
         """
         return await self._contextPromise
 
-    async def evaluateHandle(self, pageFunction: str, *args: Any) -> JSHandle:
-        """Execute fucntion on this frame.
+    async def evaluateHandle(self, pageFunction: str, *args: Any, withCliAPI: bool = False) -> JSHandle:
+        """Evaluates the js-function or js-expression in the current frame retrieving the results
+        as a JSHandle.
 
-        Details see :meth:`simplechrome.page.Page.evaluateHandle`.
+        :param str pageFunction: String of js-function/expression to be executed
+                               in the browser.
+        :param bool withCliAPI:  Determines whether Command Line API should be available during the evaluation.
+        If this keyword argument is true args are ignored
         """
         context = await self.executionContext()
         if context is None:
             raise PageError("this frame has no context.")
-        return await context.evaluateHandle(pageFunction, *args)
+        return await context.evaluateHandle(pageFunction, *args, withCliAPI=withCliAPI)
 
-    async def evaluate(self, pageFunction: str, *args: Any) -> Any:
-        """Evaluate pageFunction on this frame.
+    async def evaluate(self, pageFunction: str, *args: Any, withCliAPI: bool = False) -> Any:
+        """Evaluates the js-function or js-expression in the current frame retrieving the results
+        of the evaluation.
 
-        Details see :meth:`simplechrome.page.Page.evaluate`.
+        :param str pageFunction: String of js-function/expression to be executed
+                               in the browser.
+        :param bool withCliAPI:  Determines whether Command Line API should be available during the evaluation.
+        If this keyword argument is true args are ignored
         """
         context = await self.executionContext()
         if context is None:
             raise ElementHandleError("ExecutionContext is None.")
-        return await context.evaluate(pageFunction, *args)
+        return await context.evaluate(pageFunction, *args, withCliAPI=withCliAPI)
+
+    async def evaluate_expression(self, expression: str, withCliAPI: bool = False) -> Any:
+        """Evaluates the js expression in the frame returning the results by value.
+
+        :param str expression: The js expression to be evaluated in the main frame.
+        :param bool withCliAPI:  Determines whether Command Line API should be available during the evaluation.
+        """
+        context = await self.executionContext()
+        if context is None:
+            raise ElementHandleError("ExecutionContext is None.")
+        return await context.evaluate_expression(expression, withCliAPI=withCliAPI)
 
     async def querySelector(self, selector: str) -> Optional[ElementHandle]:
         """Get element which matches `selector` string.

--- a/simplechrome/navigator_watcher.py
+++ b/simplechrome/navigator_watcher.py
@@ -115,11 +115,6 @@ class NavigatorWatcher(object):
         self._navigationRequest = request
 
     def dispose(self) -> None:
-        self._sameDocumentNavigationPromise: Future = self.loop.create_future()
-        self._newDocumentNavigationPromise: Future = self.loop.create_future()
-        self._terminationPromise: Future = self.loop.create_future()
-        self._timeoutPromise: Union[Future, Task] = self._createTimeoutPromise()
-
         Helper.removeEventListeners(self._eventListeners)
         if self._terminationPromise and not self._terminationPromise.done():
             self._terminationPromise.cancel()

--- a/simplechrome/page.py
+++ b/simplechrome/page.py
@@ -770,21 +770,30 @@ class Page(EventEmitter):
         if needsReload:
             await self.reload()
 
-    async def evaluate(self, pageFunction: str, *args: Any) -> Any:
-        """Execute js-function or js-expression on browser and get result.
+    async def evaluate(self, pageFunction: str, *args: Any, withCliAPI: bool = False) -> Any:
+        """Evaluates the js-function or js-expression in the main frame retrieving the results
+        of the valuation.
 
-        :arg str pageFunction: String of js-function/expression to be executed
-                               on the browser.
-        :arg bool force_expr: If True, evaluate `pageFunction` as expression.
-                              If False (default), try to automatically detect
-                              function or expression.
-
-        note: ``force_expr`` option is a keyword only argument.
+        :param str pageFunction: String of js-function/expression to be executed
+                               in the browser.
+        :param bool withCliAPI:  Determines whether Command Line API should be available during the evaluation.
+        If this keyword argument is true args are ignored
         """
         frame = self.mainFrame
         if frame is None:
             raise PageError("No main frame.")
-        return await frame.evaluate(pageFunction, *args)
+        return await frame.evaluate(pageFunction, *args, withCliAPI=withCliAPI)
+
+    async def evaluate_expression(self, expression: str, withCliAPI: bool = False) -> Any:
+        """Evaluates the js expression in the main frame returning the results by value.
+
+        :param str expression: The js expression to be evaluated in the main frame.
+        :param bool withCliAPI:  Determines whether Command Line API should be available during the evaluation.
+        """
+        frame = self.mainFrame
+        if frame is None:
+            raise PageError("No main frame.")
+        return await frame.evaluate_expression(expression, withCliAPI=withCliAPI)
 
     async def evaluateOnNewDocument(
         self, pageFunction: str, *args: str, raw: bool=False

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -5,7 +5,7 @@ import time
 import pytest
 from grappa import should
 
-from simplechrome.errors import ElementHandleError, PageError, NavigationError
+from simplechrome.errors import ElementHandleError, PageError, NavigationError, EvaluationError
 from .base_test import BaseChromeTest
 from .frame_utils import attachFrame
 
@@ -54,9 +54,9 @@ class TestEvaluate(BaseChromeTest):
         frameEvaluation.result() | should.be.equal.to(42)
 
     @pytest.mark.asyncio
-    async def test_paromise_reject(self):
+    async def test_promise_reject(self):
         await self.goto_empty(waitUntil="load")
-        with pytest.raises(ElementHandleError) as cm:
+        with pytest.raises(EvaluationError) as cm:
             await self.page.evaluate("() => not.existing.object.property")
         str(cm.value) | should.contain("not is not defined")
 
@@ -187,7 +187,7 @@ class TestOfflineMode(BaseChromeTest):
         await self.page.setOfflineMode(False)
         had_error | should.be.true
         res = await self.page.reload()
-        res.status | should.be.equal.to(200)
+        (res.status in [200, 304]) | should.be.true
 
     @pytest.mark.asyncio
     async def test_emulate_navigator_offline(self):


### PR DESCRIPTION
fixed navigator_watcher dispose bug where the futures were recreated
feature: evaluation can now opt in for including the console api
feature: evaluation of expressions returning the results by value is now enabled
updated tests