### PR TITLE
v1.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 python:
   - "3.6"
 before_install:
+  - "sysctl kernel.unprivileged_userns_clone=1"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cchardet
 pyee
 websockets
 ujson
-yarl
 async-timeout
 aiofiles
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,34 @@ from setuptools import setup, find_packages
 
 requirements = [
     "aiohttp",
-    "uvloop",
     "aiodns",
     "cchardet",
     "pyee",
-    "websockets",
     "ujson",
-    "yarl",
     "async-timeout",
     "aiofiles",
     "urllib3",
     "attrs",
+    "cripy"
 ]
 
-test_requirements = ["pytest", "pytest-asyncio", "psutil", "grappa", "vibora"]
+test_requirements = ["pytest", "pytest-asyncio", "psutil", "grappa", "vibora", "uvloop"]
 
 setup(
     name="simplechrome",
-    version="1.3.1",
+    version="1.3.3",
     description=(
         "Headless chrome/chromium automation library"
         "(unofficial fork of pypuppeteer that stays more up to date with puppeteer)"
     ),
     author="Webrecorder",
     author_email="Webrecorder.Webrecorder@Webrecorder.com",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=requirements,
+    dependency_links=[
+        "git+https://github.com/webrecorder/chrome-remote-interface-py.git@master#egg=cripy"
+    ],
     zip_safe=False,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/simplechrome/__init__.py
+++ b/simplechrome/__init__.py
@@ -13,7 +13,7 @@ from .helper import *
 from .input import *
 from .launcher import *
 from .multimap import *
-from .navigator_watcher import *
+from .lifecycle_watcher import *
 from .network_manager import *
 from .page import *
 from .us_keyboard_layout import *
@@ -31,7 +31,7 @@ __all__ = (
     + input.__all__
     + launcher.__all__
     + multimap.__all__
-    + navigator_watcher.__all__
+    + lifecycle_watcher.__all__
     + network_manager.__all__
     + page.__all__
     + us_keyboard_layout.__all__

--- a/simplechrome/browser_fetcher.py
+++ b/simplechrome/browser_fetcher.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 
 import urllib3
 
-DEFAULT_REVISION = "604907"
+DEFAULT_REVISION = "608752"
 logger = logging.getLogger(__name__)
 
 __all__ = ["BrowserFetcher", "BF"]

--- a/simplechrome/connection.py
+++ b/simplechrome/connection.py
@@ -8,6 +8,7 @@ from cripy import Connection, CDPSession, TargetSession, ConnectionType, Session
 __all__ = [
     "Connection",
     "CDPSession",
+    "SessionType",
     "createForWebSocket",
     "ClientType",
     "connection_from_session",

--- a/simplechrome/dialog.py
+++ b/simplechrome/dialog.py
@@ -9,7 +9,7 @@ from .connection import ClientType
 __all__ = ["Dialog"]
 
 
-@attr.dataclass(slots=True)
+@attr.dataclass(slots=True, frozen=True)
 class DialogType(object):
     Alert: str = attr.ib(default="alert")
     BeforeUnload: str = attr.ib(default="beforeunload")
@@ -17,7 +17,7 @@ class DialogType(object):
     Prompt: str = attr.ib(default="prompt")
 
 
-@attr.dataclass
+@attr.dataclass(slots=True)
 class Dialog(object):
     """Dialog class.
 

--- a/simplechrome/emulation_manager.py
+++ b/simplechrome/emulation_manager.py
@@ -1,19 +1,20 @@
-# -*- coding: utf-8 -*-
 """Emulation Managet module."""
-from .helper import Helper
+from typing import Optional
+
+import attr
+
 from .connection import ClientType
+from .helper import Helper
 
 __all__ = ["EmulationManager"]
 
 
+@attr.dataclass(slots=True)
 class EmulationManager(object):
     """EmulationManager class."""
-
-    def __init__(self, client: ClientType) -> None:
-        """Make new elmulation manager."""
-        self._client = client
-        self._emulatingMobile = False
-        self._injectedTouchScriptId = None
+    _client: ClientType = attr.ib()
+    _emulatingMobile: bool = attr.ib(init=False, default=False)
+    _injectedTouchScriptId: Optional[str] = attr.ib(init=False, default=None)
 
     async def emulateViewport(self, viewport: dict) -> bool:
         """Evaluate viewport."""

--- a/simplechrome/errors.py
+++ b/simplechrome/errors.py
@@ -12,7 +12,9 @@ __all__ = [
     "LauncherError",
     "InputError",
     "NavigationError",
-    "EvaluationError"
+    "EvaluationError",
+    "NavigationTimeoutError",
+    "WaitSetupError"
 ]
 
 
@@ -34,7 +36,7 @@ class PageError(Exception):  # noqa: D204
     pass
 
 
-class WaitTimeoutError(asyncio.TimeoutError):  # noqa: D204
+class WaitTimeoutError(Exception):  # noqa: D204
     """Timeout Error class."""
 
     pass
@@ -56,5 +58,13 @@ class NavigationError(Exception):
     """For navigation errors"""
 
 
+class NavigationTimeoutError(Exception):
+    """For navigation timeout errors"""
+
+
 class EvaluationError(Exception):
     """For evaluation errors"""
+
+
+class WaitSetupError(Exception):
+    """Indicates a precondition for Frame wait functions was not met"""

--- a/simplechrome/input.py
+++ b/simplechrome/input.py
@@ -13,7 +13,7 @@ from .util import merge_dict
 __all__ = ["Keyboard", "Mouse", "Touchscreen"]
 
 
-@attr.dataclass
+@attr.dataclass(slots=True)
 class Keyboard(object):
     """Keyboard class."""
 
@@ -21,7 +21,9 @@ class Keyboard(object):
     modifiers: int = attr.ib(init=False, default=0)
     pressedKeys: Set[str] = attr.ib(init=False, factory=set)
 
-    async def down(self, key: str, options: Optional[Dict] = None, **kwargs: Any) -> None:
+    async def down(
+        self, key: str, options: Optional[Dict] = None, **kwargs: Any
+    ) -> None:
         """Dispatches a ``keydown`` event with ``key``.
 
         If ``key`` is a single character and no modifier keys besides ``shift``
@@ -176,7 +178,9 @@ class Keyboard(object):
             if delay:
                 await asyncio.sleep(delay / 1000)
 
-    async def press(self, key: str, options: Optional[Dict] = None, **kwargs: Any) -> None:
+    async def press(
+        self, key: str, options: Optional[Dict] = None, **kwargs: Any
+    ) -> None:
         """Press ``key``.
 
         If ``key`` is a single character and no modifier keys besides
@@ -201,9 +205,10 @@ class Keyboard(object):
         await self.up(key)
 
 
-@attr.dataclass
+@attr.dataclass(slots=True)
 class Mouse(object):
     """Mouse class."""
+
     client: ClientType = attr.ib()
     keyboard: Keyboard = attr.ib()
     _x: float = attr.ib(init=False, default=0.0)
@@ -307,9 +312,10 @@ class Mouse(object):
         )
 
 
-@attr.dataclass
+@attr.dataclass(slots=True)
 class Touchscreen(object):
     """Touchscreen class."""
+
     client: ClientType = attr.ib()
     keyboard: Keyboard = attr.ib()
 

--- a/simplechrome/target.py
+++ b/simplechrome/target.py
@@ -1,0 +1,114 @@
+from asyncio import AbstractEventLoop, Future
+from typing import Dict, Optional, TYPE_CHECKING
+
+from .connection import SessionType
+from .page import Page
+from .util import ensure_loop
+
+
+if TYPE_CHECKING:
+    from .chrome import BrowserContext, Chrome  # noqa: F401
+
+__all__ = ["Target"]
+
+
+class Target(object):
+    """Browser's target class."""
+
+    def __init__(
+        self,
+        targetInfo: Dict[str, str],
+        browserContext: "BrowserContext",
+        browser: "Chrome",
+        loop: Optional[AbstractEventLoop] = None,
+    ) -> None:
+        self._browser: Chrome = browser
+        self._browserContext: BrowserContext = browserContext
+        self._targetInfo: Dict[str, str] = targetInfo
+        self._targetId = targetInfo["targetId"]
+        self._page: Optional[Page] = None
+        self._loop = ensure_loop(loop)
+
+        self._isClosedPromise: Future = self._loop.create_future()
+        self._initializedPromise: Future = self._loop.create_future()
+        self._isInitialized = (
+            self._targetInfo["type"] != "page" or self._targetInfo["url"] != ""
+        )
+        if self._isInitialized:
+            self._initializedCallback(True)
+
+    @property
+    def opener(self) -> Optional["Target"]:
+        openerId = self._targetInfo.get("openerId")
+        if openerId is not None:
+            return self.browser._targets.get(openerId)
+        return openerId
+
+    @property
+    def browser(self) -> "Chrome":
+        return self._browserContext.browser()
+
+    @property
+    def browserContext(self) -> "BrowserContext":
+        return self._browserContext
+
+    @property
+    def url(self) -> str:
+        """Get url of this target."""
+        return self._targetInfo["url"]
+
+    @property
+    def type(self) -> str:
+        """Get type of this target."""
+        _type: str = self._targetInfo["type"]
+        if (
+            _type == "page"
+            or _type == "service_worker"
+            or _type == "page"
+            or _type == "background_page"
+            or _type == "browser"
+        ):
+            return _type
+        return "other"
+
+    async def createCDPSession(self) -> SessionType:
+        """Create a Chrome Devtools Protocol session attached to the target."""
+        return await self._browser._connection.createCDPSession(self._targetId)
+
+    async def page(self) -> Optional[Page]:
+        """Get page of this target."""
+        is_page = (
+            self._targetInfo["type"] == "page"
+            or self._targetInfo["type"] == "background_page"
+        )
+        if is_page and self._page is None:
+            client = await self._browser._connection.createCDPSession(self._targetId)
+            new_page = await Page.create(
+                client,
+                self,
+                self._browser._defaultViewport,
+                self._browser.ignoreHTTPSErrors,
+                self._browser._screenshotTaskQueue,
+                self._loop,
+            )
+            self._page = new_page
+            return new_page
+        return self._page
+
+    def targetInfoChanged(self, targetInfo: dict) -> None:
+        self._targetInfo = targetInfo
+
+        if not self._isInitialized and (
+            self._targetInfo["type"] != "page" or self._targetInfo["url"] != ""
+        ):
+            self._isInitialized = True
+            self._initializedCallback(True)
+            return
+
+    def _initializedCallback(self, bl: bool) -> None:
+        if self._initializedPromise and not self._initializedPromise.done():
+            self._initializedPromise.set_result(bl)
+
+    def _closedCallback(self) -> None:
+        if self._isClosedPromise and not self._isClosedPromise.done():
+            self._isClosedPromise.set_result(None)

--- a/simplechrome/tracing.py
+++ b/simplechrome/tracing.py
@@ -1,0 +1,87 @@
+import base64
+from typing import Any, Dict, List, Optional, Awaitable
+
+import attr
+import aiofiles
+import asyncio
+from .connection import ClientType
+from .util import merge_dict
+
+__all__ = ["Tracing"]
+
+
+@attr.dataclass(slots=True)
+class Tracing(object):
+    client: ClientType = attr.ib()
+    _recording: bool = attr.ib(init=False, default=False)
+    _path: Optional[str] = attr.ib(init=False, default="")
+
+    async def start(self, options: Optional[Dict], **kwargs: Any) -> None:
+        opts = merge_dict(options, kwargs)
+        defaultCategories: List[str] = [
+            "-*",
+            "devtools.timeline",
+            "v8.execute",
+            "disabled-by-default-devtools.timeline",
+            "disabled-by-default-devtools.timeline.frame",
+            "toplevel",
+            "blink.console",
+            "blink.user_timing",
+            "latencyInfo",
+            "disabled-by-default-devtools.timeline.stack",
+            "disabled-by-default-v8.cpu_profiler",
+            "disabled-by-default-v8.cpu_profiler.hires",
+        ]
+        path = opts.get("path", None)
+        categories = opts.get("categories", defaultCategories)
+        if opts.get("screenshots", False):
+            categories.append("disabled-by-default-devtools.screenshot")
+
+        self._path = path
+        self._recording = True
+        await self.client.send(
+            "Tracing.start",
+            dict(transferMode="ReturnAsStream", categories=",".join(categories)),
+        )
+
+    async def stop(self) -> Awaitable[bytes]:
+        contentPromise = asyncio.get_event_loop().create_future()
+
+        @self.client.once("Tracing.tracingComplete")
+        async def done(event: Dict) -> None:
+            if self._path:
+                content: bytes = await self._serialize_stream_to_file(event.get("stream"), self._path)
+            else:
+                content: bytes = await self._readStream(event.get("stream"))
+            contentPromise.set_result(content)
+
+        return contentPromise
+
+    async def _readStream(self, handle: str) -> bytes:
+        eof = False
+        content: List[bytes] = []
+        while not eof:
+            response = await self.client.send("IO.read", dict(handle=handle))
+            eof = response.get("eof")
+            if response.get("base64Encoded", False):
+                content.append(base64.b64decode(response.get("data")))
+            else:
+                content.append(response.get("data").encode("utf-8"))
+
+        await self.client.send("IO.close", dict(handle=handle))
+        return b''.join(content)
+
+    async def _serialize_stream_to_file(self, handle: str, path: str) -> bytes:
+        eof = False
+        content: List[bytes] = []
+        async with aiofiles.open(path, "wb") as out:
+            while not eof:
+                response = await self.client.send("IO.read", dict(handle=handle))
+                eof = response.get("eof")
+                if response.get("base64Encoded", False):
+                    data = base64.b64decode(response.get("data"))
+                else:
+                    data = response.get("data").encode("utf-8")
+                content.append(data)
+                await out.write(data)
+        return b''.join(content)

--- a/simplechrome/waitTask.py
+++ b/simplechrome/waitTask.py
@@ -1,0 +1,223 @@
+import asyncio
+from typing import Any, Optional, Union, TYPE_CHECKING
+
+from .errors import PageError, WaitTimeoutError
+from .execution_context import JSHandle
+from .helper import Helper
+
+if TYPE_CHECKING:
+    from .frame_manager import Frame  # noqa: F401
+
+__all__ = ["WaitTask"]
+
+
+class WaitTask(object):
+    """WaitTask class.
+
+    Instance of this class is awaitable.
+    """
+
+    def __init__(
+        self,
+        frame: "Frame",
+        predicateBody: str,
+        polling: Union[str, int, float],
+        timeout: Union[float, int],
+        *args: Any,
+    ) -> None:
+        if isinstance(polling, str):
+            if polling not in ["raf", "mutation"]:
+                raise ValueError(f"Unknown polling: {polling}")
+        elif isinstance(polling, (int, float)):
+            if polling <= 0:
+                raise ValueError(f"Cannot poll with non-positive interval: {polling}")
+        else:
+            raise ValueError(f"Unknown polling option: {polling}")
+
+        self._frame: "Frame" = frame
+        self._polling: Union[str, int, float] = polling
+        self._timeout: Union[float, int] = timeout
+        if args or Helper.is_jsfunc(predicateBody):
+            self._predicateBody = f"return ({predicateBody})(...args)"
+        else:
+            self._predicateBody = f"return {predicateBody}"
+        self._args = args
+        self._runCount = 0
+        self._terminated = False
+        self._timeoutError = False
+        frame._waitTasks.add(self)
+
+        loop = asyncio.get_event_loop()
+        self.promise = loop.create_future()
+        if timeout:
+            self._timeoutTimer = loop.create_task(self.timeout_timer(self._timeout))
+        loop.create_task(self.rerun())
+
+    async def timeout_timer(self, to: Union[int, float]) -> None:
+        await asyncio.sleep(to / 1000)
+        self._timeoutError = True
+        self.terminate(WaitTimeoutError(f"Waiting failed: timeout {to}ms exceeds."))
+
+    def __await__(self) -> Any:
+        """Make this class **awaitable**."""
+        yield from self.promise
+        return self.promise.result()
+
+    def terminate(self, error: Exception) -> None:
+        """Terminate this task."""
+        self._terminated = True
+        if self.promise and not self.promise.done():
+            self.promise.set_exception(error)
+        self._cleanup()
+
+    async def rerun(self) -> None:  # noqa: C901
+        """Start polling."""
+        runCount = self._runCount = self._runCount + 1
+        success: Optional[JSHandle] = None
+        error = None
+
+        try:
+            context = await self._frame.executionContext()
+            if context is None:
+                raise PageError("No execution context.")
+            success = await context.evaluateHandle(
+                waitForPredicatePageFunction,
+                self._predicateBody,
+                self._polling,
+                self._timeout,
+                *self._args,
+            )
+        except Exception as e:
+            error = e
+
+        if self.promise.done():
+            return
+
+        if self._terminated or runCount != self._runCount:
+            if success:
+                await success.dispose()
+            return
+
+        if (
+            error is None
+            and success
+            and (await self._frame.evaluate("s => !s", success))
+        ):
+            await success.dispose()
+            return
+
+        # page is navigated and context is destroyed.
+        # Try again in the new execution context.
+        if (
+            isinstance(error, Exception)
+            and "Execution context was destroyed" in error.args[0]
+        ):
+            return
+
+        # Try again in the new execution context.
+        if (
+            isinstance(error, Exception)
+            and "Cannot find context with specified id" in error.args[0]
+        ):
+            return
+
+        if error:
+            self.promise.set_exception(error)
+        else:
+            self.promise.set_result(success)
+
+        self._cleanup()
+
+    def _cleanup(self) -> None:
+        if self._timeout and self._timeoutTimer and not self._timeoutTimer.done():
+            self._timeoutTimer.cancel()
+        self._frame._waitTasks.remove(self)
+
+
+waitForPredicatePageFunction: str = """
+async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...args) {
+  const predicate = new Function('...args', predicateBody);
+  let timedOut = false;
+  setTimeout(() => timedOut = true, timeout);
+  if (polling === 'raf')
+    return await pollRaf();
+  if (polling === 'mutation')
+    return await pollMutation();
+  if (typeof polling === 'number')
+    return await pollInterval(polling);
+
+  /**
+   * @return {!Promise<*>}
+   */
+  function pollMutation() {
+    const success = predicate.apply(null, args);
+    if (success)
+      return Promise.resolve(success);
+
+    let fulfill;
+    const result = new Promise(x => fulfill = x);
+    const observer = new MutationObserver(mutations => {
+      if (timedOut) {
+        observer.disconnect();
+        fulfill();
+      }
+      const success = predicate.apply(null, args);
+      if (success) {
+        observer.disconnect();
+        fulfill(success);
+      }
+    });
+    observer.observe(document, {
+      childList: true,
+      subtree: true,
+      attributes: true
+    });
+    return result;
+  }
+
+  /**
+   * @return {!Promise<*>}
+   */
+  function pollRaf() {
+    let fulfill;
+    const result = new Promise(x => fulfill = x);
+    onRaf();
+    return result;
+
+    function onRaf() {
+      if (timedOut) {
+        fulfill();
+        return;
+      }
+      const success = predicate.apply(null, args);
+      if (success)
+        fulfill(success);
+      else
+        requestAnimationFrame(onRaf);
+    }
+  }
+
+  /**
+   * @param {number} pollInterval
+   * @return {!Promise<*>}
+   */
+  function pollInterval(pollInterval) {
+    let fulfill;
+    const result = new Promise(x => fulfill = x);
+    onTimeout();
+    return result;
+
+    function onTimeout() {
+      if (timedOut) {
+        fulfill();
+        return;
+      }
+      const success = predicate.apply(null, args);
+      if (success)
+        fulfill(success);
+      else
+        setTimeout(onTimeout, pollInterval);
+    }
+  }
+}
+"""

--- a/simplechrome/worker.py
+++ b/simplechrome/worker.py
@@ -20,4 +20,3 @@ class Worker(EventEmitter):
         self._client = client
         self._url = url
         self._executionContextPromise = self._loop.create_future()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
+import os
 from typing import Any, AsyncGenerator, Generator
 
-import os
 import psutil
 import pytest
 import uvloop
@@ -57,6 +57,7 @@ async def chrome_page(request, chrome: Chrome) -> AsyncGenerator[Page, Any]:
 @pytest.yield_fixture(scope="class")
 def event_loop() -> Generator[uvloop.Loop, Any, None]:
     loop = uvloop.new_event_loop()
+    loop.set_debug(True)
     yield loop
     loop.close()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -52,7 +52,7 @@ class TestConnection(object):
 class TestCDPSession(BaseChromeTest):
     @pytest.mark.asyncio
     async def test_create_session(self):
-        client = await self.page.target.createTargetSession()
+        client = await self.page.target.createCDPSession()
         await client.send("Runtime.enable")
         await client.send("Runtime.evaluate", {"expression": 'window.foo = "bar"'})
         await self.page.evaluate("window.foo") | should.be.equal.to("bar")
@@ -60,7 +60,7 @@ class TestCDPSession(BaseChromeTest):
 
     @pytest.mark.asyncio
     async def test_send_event(self, ee_helper):
-        client = await self.page.target.createTargetSession()
+        client = await self.page.target.createCDPSession()
         await client.send("Network.enable")
         events = []
         ee_helper.addEventListener(
@@ -72,7 +72,7 @@ class TestCDPSession(BaseChromeTest):
 
     @pytest.mark.asyncio
     async def test_enable_disable_domain(self):
-        client = await self.page.target.createTargetSession()
+        client = await self.page.target.createCDPSession()
         await client.send("Runtime.enable")
         await client.send("Runtime.disable")
         res = await client.send(
@@ -84,7 +84,7 @@ class TestCDPSession(BaseChromeTest):
 
     @pytest.mark.asyncio
     async def test_detach(self):
-        client = await self.page.target.createTargetSession()
+        client = await self.page.target.createCDPSession()
         await client.send("Runtime.enable")
         evalResponse = await client.send(
             "Runtime.evaluate", {"expression": "1 + 2", "returnByValue": True}

--- a/tests/test_element_handle.py
+++ b/tests/test_element_handle.py
@@ -74,7 +74,7 @@ class TestClick(BaseChromeTest):
         await self.page.evaluate('btn => btn.style.display = "none"', button)
         with pytest.raises(ElementHandleError) as cm:
             await button.click()
-        str(cm.value) | should.be.equal.to("Node is not visible.")
+        str(cm.value) | should.be.equal.to("Node is either not visible or not an HTMLElement")
 
     @pytest.mark.asyncio
     async def test_recursively_hidden_node(self):
@@ -85,16 +85,15 @@ class TestClick(BaseChromeTest):
         )
         with pytest.raises(ElementHandleError) as cm:
             await button.click()
-        str(cm.value) | should.be.equal.to("Node is not visible.")
+        str(cm.value) | should.be.equal.to("Node is either not visible or not an HTMLElement")
 
     @pytest.mark.asyncio
     async def test_br_node(self):
-        await self.goto_empty()
         await self.page.setContent("hello<br>goodbye")
         br = await self.page.J("br")
         with pytest.raises(ElementHandleError) as cm:
             await br.click()
-        str(cm.value) | should.be.equal.to("Node is not visible.")
+        str(cm.value) | should.be.equal.to("Node is either not visible or not an HTMLElement")
 
 
 class TestHover(BaseChromeTest):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -5,7 +5,7 @@ import time
 import pytest
 from grappa import should
 
-from simplechrome.errors import ElementHandleError, PageError, NavigationError, EvaluationError
+from simplechrome.errors import ElementHandleError, PageError, NavigationTimeoutError, EvaluationError
 from .base_test import BaseChromeTest
 from .frame_utils import attachFrame
 
@@ -475,6 +475,6 @@ class TestUrl(BaseChromeTest):
 class TestGoto(BaseChromeTest):
     @pytest.mark.asyncio
     async def test_goto_time_out(self):
-        with pytest.raises(NavigationError, message="Navigation Timeout Exceeded: 5 seconds exceeded"):
+        with pytest.raises(NavigationTimeoutError, message="Navigation Timeout Exceeded: 5 seconds exceeded"):
             await self.goto_test('never-loads1.html', waitUntil="load", timeout=5)
 


### PR DESCRIPTION
include cripy in requires and dep-link
updated connection to be aware of cripy.connection changes
moved Target and WaitTask to own files
implemented tracing
made the event and type name classes frozen
Introduced NavigationTimeout error to better indicate if a navigation condition was not met within before the supplied timeout value was hit

bumped version to puppeteer v1.11.0-post (ish)